### PR TITLE
Implement tenant scope and client-service pivot

### DIFF
--- a/backend/app/Models/Cliente.php
+++ b/backend/app/Models/Cliente.php
@@ -4,11 +4,16 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Traits\BelongsToTenant;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use App\Models\Servicio;
 
 class Cliente extends Model
 {
-
     use HasFactory;
+    use SoftDeletes;
+    use BelongsToTenant;
 
 
     protected $table = 'clientes';
@@ -21,8 +26,7 @@ class Cliente extends Model
         'ciudad',
         'telefono',
         'email',
-        'fecha_registro',
-        'activo'
+        'tenant_id'
     ];
 
     // Relación 1:N con contactos_empresas
@@ -46,5 +50,12 @@ class Cliente extends Model
     public function ubicaciones()
     {
         return $this->hasMany(UbicacionCliente::class, 'id_ubicacion');
+    }
+
+    public function servicios(): BelongsToMany
+    {
+        return $this->belongsToMany(Servicio::class, 'cliente_servicio', 'cliente_id', 'servicio_id')
+            ->withPivot(['precio_negociado', 'condiciones', 'vigencia_desde', 'vigencia_hasta'])
+            ->withTimestamps();
     }
 }

--- a/backend/app/Models/ContactosEmpresa.php
+++ b/backend/app/Models/ContactosEmpresa.php
@@ -3,17 +3,24 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Traits\BelongsToTenant;
 
 class ContactosEmpresa extends Model
 {
-    protected $table = 'contactos_clientes';
+    use SoftDeletes;
+    use BelongsToTenant;
+
+    protected $table = 'contactos_empresas';
 
     protected $fillable = [
         'id_cliente',
         'nombre_contacto',
         'telefono',
         'email',
-        'cargo'
+        'cargo',
+        'principal',
+        'tenant_id'
     ];
 
     // Relación N:1 con clientes

--- a/backend/app/Models/Servicio.php
+++ b/backend/app/Models/Servicio.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use App\Models\Cliente;
 
 class Servicio extends Model
 {
@@ -30,5 +32,12 @@ class Servicio extends Model
     public function padre(): BelongsTo
     {
         return $this->belongsTo(Servicio::class, 'parent_id_servicio', 'id_servicio');
+    }
+
+    public function clientes(): BelongsToMany
+    {
+        return $this->belongsToMany(Cliente::class, 'cliente_servicio', 'servicio_id', 'cliente_id')
+            ->withPivot(['precio_negociado', 'condiciones', 'vigencia_desde', 'vigencia_hasta'])
+            ->withTimestamps();
     }
 }

--- a/backend/app/Scopes/TenantScope.php
+++ b/backend/app/Scopes/TenantScope.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class TenantScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $tenantId = session('tenant_id');
+
+        if ($tenantId) {
+            $builder->where($model->getTable() . '.tenant_id', $tenantId);
+        }
+    }
+}

--- a/backend/app/Traits/BelongsToTenant.php
+++ b/backend/app/Traits/BelongsToTenant.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Traits;
+
+use App\Scopes\TenantScope;
+
+trait BelongsToTenant
+{
+    protected static function bootBelongsToTenant(): void
+    {
+        static::addGlobalScope(new TenantScope());
+
+        static::creating(function ($model) {
+            if (session()->has('tenant_id')) {
+                $model->tenant_id = session('tenant_id');
+            }
+        });
+    }
+}

--- a/backend/database/migrations/2025_04_01_000001_update_clientes_and_contactos_tables.php
+++ b/backend/database/migrations/2025_04_01_000001_update_clientes_and_contactos_tables.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('clientes', function (Blueprint $table) {
+            $table->unsignedBigInteger('tenant_id')->after('id_cliente');
+            $table->softDeletes();
+            $table->unique('cif');
+            $table->unique(['razon_social', 'cif']);
+            $table->dropColumn(['fecha_registro', 'activo']);
+        });
+
+        Schema::table('contactos_empresas', function (Blueprint $table) {
+            $table->unsignedBigInteger('tenant_id')->after('id_contacto');
+            $table->boolean('principal')->default(false)->after('cargo');
+            $table->softDeletes();
+            $table->index('id_cliente');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contactos_empresas', function (Blueprint $table) {
+            $table->dropIndex(['id_cliente']);
+            $table->dropSoftDeletes();
+            $table->dropColumn(['tenant_id', 'principal']);
+        });
+
+        Schema::table('clientes', function (Blueprint $table) {
+            $table->date('fecha_registro')->default(now());
+            $table->tinyInteger('activo')->default(1);
+            $table->dropUnique(['cif']);
+            $table->dropUnique(['razon_social', 'cif']);
+            $table->dropSoftDeletes();
+            $table->dropColumn('tenant_id');
+        });
+    }
+};

--- a/backend/database/migrations/2025_04_01_000002_create_cliente_servicio_table.php
+++ b/backend/database/migrations/2025_04_01_000002_create_cliente_servicio_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('cliente_servicio', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id');
+            $table->unsignedBigInteger('cliente_id');
+            $table->unsignedBigInteger('servicio_id');
+            $table->decimal('precio_negociado', 10, 2)->unsigned()->default(0);
+            $table->text('condiciones')->nullable();
+            $table->date('vigencia_desde')->nullable();
+            $table->date('vigencia_hasta')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('cliente_id')->references('id_cliente')->on('clientes')->onDelete('cascade');
+            $table->foreign('servicio_id')->references('id_servicio')->on('servicios')->onDelete('cascade');
+            $table->index(['cliente_id', 'servicio_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cliente_servicio');
+    }
+};


### PR DESCRIPTION
## Summary
- add global TenantScope and BelongsToTenant trait
- update Cliente and ContactosEmpresa models to use tenant and soft deletes
- allow Servicio and Cliente to connect via pivot table
- migration to add tenant columns and soft deletes
- migration for cliente_servicio pivot

## Testing
- `php`: *not available*


------
https://chatgpt.com/codex/tasks/task_e_6841e8e990848324a9aebb5c74b5cc35